### PR TITLE
fix bbtools stalling issue

### DIFF
--- a/tasks/task_bbtools.wdl
+++ b/tasks/task_bbtools.wdl
@@ -31,6 +31,8 @@ task assembly_prep {
       ref=/bbmap/resources/phix174_ill.ref.fa.gz \
       k=31 \
       hdist=1 \
+      bgzip=f \
+      unbgzip=f \
       stats=~{samplename}.phix.stats.txt
 
     grep Matched ~{samplename}.phix.stats.txt | awk '{print $3}' > PHIX_RATIO

--- a/tasks/task_version.wdl
+++ b/tasks/task_version.wdl
@@ -9,7 +9,7 @@ task version_capture {
   }
 
   command <<<
-    cbird_version="C-BIRD v2.3.0"
+    cbird_version="C-BIRD v2.3.1"
     ~{default='' 'export TZ=' + timezone}
     date +"%Y-%m-%d" > TODAY
     echo "$cbird_version" > CBIRD_VERSION


### PR DESCRIPTION
Closes #11 

Updated the `bbduk` command to use standard decompression protocols `bgzip=f unbgzip=f` by default, bypassing the `BgzfInputStreamMT2` reader.